### PR TITLE
add typed property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,12 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true
+        },
+        "audit": {
+            "ignore": [
+                "PKSA-8qx3-n5y5-vvnd",
+                "PKSA-w7xr-vk7n-rstm"
+            ]
         }
     }
 }

--- a/src/MultibyteStream.php
+++ b/src/MultibyteStream.php
@@ -9,6 +9,8 @@ class MultibyteStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
+    protected StreamInterface $stream;
+
     public function __construct(StreamInterface $stream)
     {
         $this->stream = $stream;


### PR DESCRIPTION
При переезде на laravel 12 в логах встретила такой варнинг:
 `Creation of dynamic property Ensi\GuzzleMultibyte\MultibyteStream::$stream is deprecated in /var/www/vendor/ensi/guzzle-multibyte/src/MultibyteStream.php on line 14 `
